### PR TITLE
Expose ProtocolHandlerPlugin so it's possible to call 'handleEventURL' for multiple plugins

### DIFF
--- a/macos/Classes/ProtocolHandlerPlugin.swift
+++ b/macos/Classes/ProtocolHandlerPlugin.swift
@@ -2,9 +2,15 @@ import Cocoa
 import FlutterMacOS
 
 public class ProtocolHandlerPlugin: NSObject, FlutterPlugin  {
+    private static var _instance: ProtocolHandlerPlugin?
     private var channel: FlutterMethodChannel!
-    
     private var _initialUrl: String?
+  
+    public static var instance: ProtocolHandlerPlugin {
+      get {
+        return _instance!
+      }
+    }
     
     override init(){
         super.init();
@@ -14,12 +20,13 @@ public class ProtocolHandlerPlugin: NSObject, FlutterPlugin  {
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: "protocol_handler", binaryMessenger: registrar.messenger)
         let instance = ProtocolHandlerPlugin()
+        _instance = instance
         instance.channel = channel
         registrar.addMethodCallDelegate(instance, channel: channel)
     }
     
     @objc
-    private func handleURLEvent(_ event: NSAppleEventDescriptor, with replyEvent: NSAppleEventDescriptor) {
+    public func handleURLEvent(_ event: NSAppleEventDescriptor, with replyEvent: NSAppleEventDescriptor) {
         guard let urlString = event.paramDescriptor(forKeyword: AEKeyword(keyDirectObject))?.stringValue else { return }
         if (_initialUrl == nil) {
             _initialUrl = urlString


### PR DESCRIPTION
We've run into the issue that we have multiple plugins that depend on setting an event handler through `NSAppleEventManager.shared().setEventHandler`, the next one always overwriting the previous one.

We are looking into exposing the handler methods on those plugins so we can achieve something like this:

```swift
    public func handleURLEvent(_ event: NSAppleEventDescriptor, with replyEvent: NSAppleEventDescriptor) {
        HandlerA.instance.handleURLEvent(...)
        HandlerB.instance.handleURLEvent(...)
       // other handlers
    }
```

Please let me know what you think of this approach (or if you have any better ideas for our issue)